### PR TITLE
Add option for setting inter-character delay

### DIFF
--- a/src/include/gotty/options.h
+++ b/src/include/gotty/options.h
@@ -33,6 +33,7 @@ struct option_t
     char tty_device[MAXPATHLEN];
     bool no_autoconnect;
     struct termios tio;
+    int char_delay;
 };
 
 extern struct option_t option;

--- a/src/options.c
+++ b/src/options.c
@@ -43,6 +43,7 @@ void print_options_help(char *argv[])
     printf("\n");
     printf("Options:\n");
     printf("  -b, --baudrate <baudrate>   Baud rate (default: 115200)\n");
+    printf("  -c, --char-delay <ms>       Character delay (default: 0)\n");
     printf("  -d, --databits 5|6|7|8      Data bits (default: 8)\n");
     printf("  -f, --flow hard|soft|none   Flow control (default: none)\n");
     printf("  -s, --stopbits 1|2          Stop bits (default: 1)\n");
@@ -73,6 +74,9 @@ void parse_options(int argc, char *argv[])
     bzero(&option.tio, sizeof(option.tio));
     option.tio.c_cflag = B115200 | CS8;
 
+    /* Set default char delay */
+    option.char_delay = 0;
+
     while (1)
     {
         static struct option long_options[] =
@@ -85,6 +89,7 @@ void parse_options(int argc, char *argv[])
             {"no-autoconnect", no_argument,       0, 'n'},
             {"version",	       no_argument,       0, 'v'},
             {"help",           no_argument,       0, 'h'},
+            {"char-delay",     required_argument, 0, 'c'},
             {0,                0,                 0,  0 }
         };
 
@@ -92,7 +97,7 @@ void parse_options(int argc, char *argv[])
         int option_index = 0;
 
         /* Parse argument using getopt_long */
-        c = getopt_long(argc, argv, "b:d:f:s:p:nvh", long_options, &option_index);
+        c = getopt_long(argc, argv, "b:c:d:f:s:p:nvh", long_options, &option_index);
 
         /* Detect the end of the options */
         if (c == -1)
@@ -209,6 +214,10 @@ void parse_options(int argc, char *argv[])
                 cfsetispeed(&option.tio, baudrate);
                 cfsetospeed(&option.tio, baudrate);
 
+                break;
+
+            case 'c':
+                option.char_delay = atoi(optarg);
                 break;
 
             case 'd':

--- a/src/tty.c
+++ b/src/tty.c
@@ -234,6 +234,10 @@ int connect_tty(void)
 
             /* Forward input to tty device */
             status = write(fd, &c_stdin[0], 1);
+
+	    /* Insert char delay */
+	    if (option.char_delay)
+		    usleep(option.char_delay * 1000);
         }
     }
 


### PR DESCRIPTION
This patch adds an option to insert a small delay between transmitted bytes. This is useful when working with slow devices that cant process incoming bytes at full wire speed.