### PR TITLE
Don't hardcode path for bash completions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,9 @@ AM_SILENT_RULES([yes])
 AC_PROG_CC
 AC_LANG([C])
 AC_PROG_INSTALL
+PKG_PROG_PKG_CONFIG
+PKG_CHECK_VAR(bashcompdir, [bash-completion], [completionsdir], , bashcompdir="${sysconfdir}/bash_completion.d")
+AC_SUBST(bashcompdir)
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([src/Makefile])
 AC_CONFIG_FILES([man/Makefile])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,5 +7,5 @@ gotty_SOURCES = tty.c \
                 include/gotty/options.h \
                 include/gotty/time.h \
                 include/gotty/print.h
-bashcompletiondir=$(sysconfdir)/bash_completion.d
+bashcompletiondir=@bashcompdir@
 dist_bashcompletion_DATA=bash-completion/gotty


### PR DESCRIPTION
Instead, use pkg-config to find out where the completions should go.

While packaging 1.4 for Debian, I stumbled across https://bugs.debian.org/776954 so this updates configure.ac and Makefile.am to be in line with the instructions from https://github.com/scop/bash-completion.